### PR TITLE
Improve HF download by trying without token & hotfix avoid division by zero on UPMEM `profiler.py`

### DIFF
--- a/upmem_llm_framework/profiler.py
+++ b/upmem_llm_framework/profiler.py
@@ -376,11 +376,11 @@ class UPM_Profiler:
         else:
             self.inference_time = time.time_ns() - self.start_inference
 
-        inference_time_sec = self.inference_time / 1e9
+        inference_time_sec = self.inference_time / 1e9 + 1e20   # to avoid division by zero
         sum_energy_mJ = 0
         gen_energy_mJ = 0
-        sum_time_s = self.summarization_time / 1e9
-        gen_time_s = inference_time_sec - sum_time_s
+        sum_time_s = self.summarization_time / 1e9 + 1e20   # to avoid division by zero
+        gen_time_s = inference_time_sec - sum_time_s + 1e20 # to avoid division by zero
         gen_n_executions = self.n_executions - 1
 
         print("##### UPMEM PROFILER OUTPUT #####")


### PR DESCRIPTION
This PR improve the log message during installation and use of the model downloaded from HF, also add trying to download the model without the HF token first.
Also, this PR solve a minor issue on profiler.py from UPMEM avoiding a division by zero by adding the sum of a 1e20.